### PR TITLE
Required keys

### DIFF
--- a/index.js
+++ b/index.js
@@ -76,7 +76,7 @@ Decorator.prototype.getTile = function(z, x, y, callback) {
                 }
                 TileDecorator.decorateLayer(layer, source.keepKeys, replies, source.requiredKeys);
                 TileDecorator.mergeLayer(layer);
-                zlib.gzip(TileDecorator.write(tile), callback);
+                zlib.gzip(new Buffer(TileDecorator.write(tile)), callback);
             });
         });
     });

--- a/index.js
+++ b/index.js
@@ -27,6 +27,8 @@ function Decorator(uri, callback) {
 
     this.key = uri.key || uri.query.key;
     this.keepKeys = (uri.keepKeys || uri.query.keepKeys).split(',');
+    this.requiredKeys = uri.requiredKeys || uri.query.requiredKeys;
+    if (this.requiredKeys) this.requiredKeys = this.requiredKeys.split(',');
     this.client = redis.createClient(uri.redis || uri.query.redis);
     this.cache = new LRU({max: 10000});
 
@@ -72,7 +74,7 @@ Decorator.prototype.getTile = function(z, x, y, callback) {
                     if (typeof replies[i] !== 'object')
                         return callback(new Error('Invalid attribute data: ' + replies[i]));
                 }
-                TileDecorator.decorateLayer(layer, source.keepKeys, replies);
+                TileDecorator.decorateLayer(layer, source.keepKeys, replies, source.requiredKeys);
                 TileDecorator.mergeLayer(layer);
                 zlib.gzip(TileDecorator.write(tile), callback);
             });

--- a/test/index.js
+++ b/test/index.js
@@ -60,7 +60,7 @@ tape('setup source directly', function(assert) {
             assert.ifError(err);
             source.getTile(14, 4831, 6159, function(err, tile) {
                 assert.ifError(err);
-                assert.equal(tile.length, 498, 'buffer size check');
+                assert.equal(tile.length, 489, 'buffer size check');
                 zlib.gunzip(tile, function(err, buffer) {
                     assert.ifError(err);
                     var tile = new VectorTile(new Protobuf(buffer));

--- a/test/index.js
+++ b/test/index.js
@@ -36,12 +36,13 @@ tape('load with decorator+s3 uri', function(assert) {
     TileliveDecorator.registerProtocols(tilelive);
     TileliveS3.registerProtocols(tilelive);
     tilelive.load('decorator+s3://test/{z}/{x}/{y}' +
-            '?key=BoroCode&keepKeys=BoroCode,BoroName,Shape_Area' +
+            '?key=BoroCode&keepKeys=BoroCode,BoroName,Shape_Area&requiredKeys=BoroCode' +
             '&redis=redis://localhost:6379', function(err, source) {
         assert.ifError(err);
         assert.equal(source.key, 'BoroCode');
         assert.equal(source.client.address, 'localhost:6379');
         assert.equal(source._fromSource instanceof TileliveS3, true);
+        assert.deepEqual(source.requiredKeys, ['BoroCode']);
         source.client.unref();
         assert.end();
     });


### PR DESCRIPTION
This PR adds the requiredKeys property discussed in https://github.com/mapbox/tile-decorator/issues/2.

Notes:
- [x] Depends on https://github.com/mapbox/tile-decorator/pull/5
- [x] Remove 2cfff86 before merging and bump tile-decorator version. (^1.0.0 will get tile-decorator 1.2.0)

cc: @mourner @aaronlidman 