### PR TITLE
if keepKeysRedis, use hmget instead of hgetall

### DIFF
--- a/index.js
+++ b/index.js
@@ -132,7 +132,7 @@ function loadAttributes(useHashes, keepKeysRedis, requiredKeysRedis, keys, clien
             }
         }
         // Insert redis-loaded values into the right positions and set in LRU cache.
-        loaded.forEach(function (val, i) {
+        loaded.forEach(function(val, i) {
             // skip other checks if we know val is null
             if (val === null) return setInCache(val, i);
             if (keepKeysRedis && useHashes) {
@@ -140,7 +140,7 @@ function loadAttributes(useHashes, keepKeysRedis, requiredKeysRedis, keys, clien
                 // instead of HGETALL, which means the response is an array that
                 // we need to fix into an object
                 var newval = {};
-                for (var k = 0; k < keepKeysRedis.length; k++) {
+                for (var k = 0; k < keepKeysRedis.length; k++) { // eslint-disable-line no-redeclare
                     newval[keepKeysRedis[k]] = val[k];
                 }
                 val = newval;
@@ -148,7 +148,7 @@ function loadAttributes(useHashes, keepKeysRedis, requiredKeysRedis, keys, clien
 
 
             if (requiredKeysRedis) {
-                for (var k = 0; k < requiredKeysRedis.length; k++) {
+                for (var k = 0; k < requiredKeysRedis.length; k++) { // eslint-disable-line no-redeclare
                     var required = requiredKeysRedis[k];
                     // If it doesn't have a required key, bail out
                     if (!val.hasOwnProperty(required) || val[required] === null) {
@@ -158,8 +158,8 @@ function loadAttributes(useHashes, keepKeysRedis, requiredKeysRedis, keys, clien
             }
             if (keepKeysRedis) {
                 var keep = {};
-                for (var j = 0; j < keepKeysRedis.length; j++) {
-                    var key = keepKeysRedis[j];
+                for (var k = 0; k < keepKeysRedis.length; k++) { // eslint-disable-line no-redeclare
+                    var key = keepKeysRedis[k];
                     if (val.hasOwnProperty(key)) keep[key] = val[key];
                 }
                 val = keep;

--- a/index.js
+++ b/index.js
@@ -74,39 +74,8 @@ Decorator.prototype.getTile = function(z, x, y, callback) {
 
             var keysToGet = TileDecorator.getLayerValues(layer, source.key);
 
-            loadAttributes(useHashes, keysToGet, client, cache, function(err, replies) {
-                if (err) callback(err);
-                if (!useHashes) replies = replies.map(JSON.parse);
-
-                for (var i = 0; i < replies.length; i++) {
-                    if (typeof replies[i] !== 'object') {
-                        return callback(new Error('Invalid attribute data: ' + replies[i]));
-                    }
-
-                    if (replies[i] === null) continue; // skip checking
-
-                    if (source.requiredKeysRedis) {
-                        for (var k = 0; k < source.requiredKeysRedis.length; k++) {
-                            if (!replies[i].hasOwnProperty(source.requiredKeysRedis[k])) {
-                                replies[i] = null; // empty this reply
-                                break;
-                            }
-                        }
-                    }
-                }
-
-                if (source.keepKeysRedis) {
-                    replies = replies.map(function(reply) {
-                        if (reply === null) return reply;
-
-                        var keep = {};
-                        for (var k = 0; k < source.keepKeysRedis.length; k++) {
-                            var key = source.keepKeysRedis[k];
-                            if (reply.hasOwnProperty(key)) keep[key] = reply[key];
-                        }
-                        return keep;
-                    });
-                }
+            loadAttributes(useHashes, source.keepKeysRedis, source.requiredKeysRedis, keysToGet, client, cache, function(err, replies) {
+                if (err) return callback(err);
 
                 TileDecorator.decorateLayer(layer, source.keepKeys, replies, source.requiredKeys, source.propertyTransform);
                 TileDecorator.mergeLayer(layer);
@@ -116,7 +85,7 @@ Decorator.prototype.getTile = function(z, x, y, callback) {
     });
 };
 
-function loadAttributes(useHashes, keys, client, cache, callback) {
+function loadAttributes(useHashes, keepKeysRedis, requiredKeysRedis, keys, client, cache, callback) {
     // Grab cached values from LRU, leave
     // remaining for retrieval from redis.
     var replies = [];
@@ -131,7 +100,11 @@ function loadAttributes(useHashes, keys, client, cache, callback) {
             replies[i] = cached;
         } else {
             if (useHashes) {
-                multi.hgetall(keys[i]);
+                if (keepKeysRedis) {
+                    multi.hmget(keys[i], keepKeysRedis.slice());
+                } else {
+                    multi.hgetall(keys[i]);
+                }
             } else {
                 multi.get(keys[i]);
             }
@@ -146,11 +119,54 @@ function loadAttributes(useHashes, keys, client, cache, callback) {
     multi.exec(function(err, loaded) {
         if (err) return callback(err);
 
-        // Insert redis-loaded values into the right positions and set in LRU cache.
-        for (var i = 0; i < loaded.length; i++) {
-            replies[loadPos[i]] = loaded[i];
-            cache.set(loadKeys[i], loaded[i]);
+        function setInCache(val, i) {
+            replies[loadPos[i]] = val;
+            cache.set(loadKeys[i], val);
         }
+
+        for (var i = 0; i < loaded.length; i++) {
+            if (!useHashes) loaded[i] = JSON.parse(loaded[i]);
+
+            if (typeof loaded[i] !== 'object') {
+                return callback(new Error('Invalid attribute data: ' + loaded[i]));
+            }
+        }
+        // Insert redis-loaded values into the right positions and set in LRU cache.
+        loaded.forEach(function (val, i) {
+            // skip other checks if we know val is null
+            if (val === null) return setInCache(val, i);
+            if (keepKeysRedis && useHashes) {
+                // If we're using hashes and there are keepKeysRedis, we used HMGET
+                // instead of HGETALL, which means the response is an array that
+                // we need to fix into an object
+                var newval = {};
+                for (var k = 0; k < keepKeysRedis.length; k++) {
+                    newval[keepKeysRedis[k]] = val[k];
+                }
+                val = newval;
+            }
+
+
+            if (requiredKeysRedis) {
+                for (var k = 0; k < requiredKeysRedis.length; k++) {
+                    var required = requiredKeysRedis[k];
+                    // If it doesn't have a required key, bail out
+                    if (!val.hasOwnProperty(required) || val[required] === null) {
+                        return setInCache(null, i);
+                    }
+                }
+            }
+            if (keepKeysRedis) {
+                var keep = {};
+                for (var j = 0; j < keepKeysRedis.length; j++) {
+                    var key = keepKeysRedis[j];
+                    if (val.hasOwnProperty(key)) keep[key] = val[key];
+                }
+                val = keep;
+            }
+
+            setInCache(val, i);
+        });
 
         return callback(null, replies, loaded.length);
     });

--- a/test/index.js
+++ b/test/index.js
@@ -344,7 +344,7 @@ tape('loadAttributes (using hashes)', function(assert) {
 
 tape('loadAttributes (using hashes, keepKeys)', function(assert) {
     cache.reset();
-    TileliveDecorator.loadAttributes(true, ['foo'], null, ['1', '2'], client, cache, function(err, replies, loaded) {
+    TileliveDecorator.loadAttributes(true, ['foo'], null, ['1', '2'], client, cache, function(err, replies) {
         assert.ifError(err);
         assert.deepEqual(replies, [{foo: '1'}, {foo: '2'}], 'loads');
         assert.end();
@@ -353,7 +353,7 @@ tape('loadAttributes (using hashes, keepKeys)', function(assert) {
 
 tape('loadAttributes (using hashes, requiredKeys)', function(assert) {
     cache.reset();
-    TileliveDecorator.loadAttributes(true, ['foo', 'baz'], ['baz'], ['1', '2', '3', '4'], client, cache, function(err, replies, loaded) {
+    TileliveDecorator.loadAttributes(true, ['foo', 'baz'], ['baz'], ['1', '2', '3', '4'], client, cache, function(err, replies) {
         assert.ifError(err);
         assert.deepEqual(replies, [null, null, {foo: '3', baz: '3'}, {foo: '4', baz: '4'}], 'loads');
         assert.end();

--- a/test/index.js
+++ b/test/index.js
@@ -282,34 +282,34 @@ tape('lru setup', function(assert) {
 });
 
 tape('loadAttributes (cache miss)', function(assert) {
-    TileliveDecorator.loadAttributes(false, ['1', '2'], client, cache, function(err, replies, loaded) {
+    TileliveDecorator.loadAttributes(false, null, null, ['1', '2'], client, cache, function(err, replies, loaded) {
         assert.ifError(err);
-        assert.deepEqual(replies, ['{"foo":1}', '{"foo":2}'], 'loads');
-        assert.equal(cache.get('1'), '{"foo":1}', 'sets item 1 in cache');
-        assert.equal(cache.get('2'), '{"foo":2}', 'sets item 2 in cache');
+        assert.deepEqual(replies, [{'foo': 1}, {'foo': 2}], 'loads');
+        assert.deepEqual(cache.get('1'), {foo: 1}, 'sets item 1 in cache');
+        assert.deepEqual(cache.get('2'), {foo: 2}, 'sets item 2 in cache');
         assert.equal(loaded, 2, '2 items loaded from redis');
         assert.end();
     });
 });
 
 tape('loadAttributes (cache hit)', function(assert) {
-    TileliveDecorator.loadAttributes(false, ['1', '2'], client, cache, function(err, replies, loaded) {
+    TileliveDecorator.loadAttributes(false, null, null, ['1', '2'], client, cache, function(err, replies, loaded) {
         assert.ifError(err);
-        assert.deepEqual(replies, ['{"foo":1}', '{"foo":2}'], 'loads');
+        assert.deepEqual(replies, [{'foo': 1}, {'foo': 2}], 'loads');
         assert.equal(loaded, 0, '0 items loaded from redis');
         assert.end();
     });
 });
 
 tape('loadAttributes (cache mixed)', function(assert) {
-    TileliveDecorator.loadAttributes(false, ['1', '3', '2', '4'], client, cache, function(err, replies, loaded) {
+    TileliveDecorator.loadAttributes(false, null, null, ['1', '3', '2', '4'], client, cache, function(err, replies, loaded) {
         assert.ifError(err);
-        assert.deepEqual(replies, ['{"foo":1}', '{"foo":3}', '{"foo":2}', '{"foo":4}'], 'loads');
-        assert.equal(cache.get('1'), '{"foo":1}', 'sets item 1 in cache');
-        assert.equal(cache.get('2'), '{"foo":2}', 'sets item 2 in cache');
-        assert.equal(cache.get('3'), '{"foo":3}', 'sets item 3 in cache');
-        assert.equal(cache.get('4'), '{"foo":4}', 'sets item 4 in cache');
-        assert.equal(loaded, 2, '2 items loaded from redis');
+        assert.deepEqual(replies, [{'foo': 1}, {'foo': 3}, {'foo': 2}, {'foo': 4}], 'loads');
+        assert.deepEqual(cache.get('1'), {'foo': 1}, 'sets item 1 in cache');
+        assert.deepEqual(cache.get('2'), {'foo': 2}, 'sets item 2 in cache');
+        assert.deepEqual(cache.get('3'), {'foo': 3}, 'sets item 3 in cache');
+        assert.deepEqual(cache.get('4'), {'foo': 4}, 'sets item 4 in cache');
+        assert.deepEqual(loaded, 2, '2 items loaded from redis');
         assert.end();
     });
 });
@@ -326,18 +326,36 @@ tape('lru teardown', function(assert) {
 tape('lru setup', function(assert) {
     client = redis.createClient();
     var multi = client.multi();
-    multi.hset('1', 'foo', 1);
-    multi.hset('2', 'foo', 2);
-    multi.hset('3', 'foo', 3);
-    multi.hset('4', 'foo', 4);
+    multi.hmset('1', 'foo', 1, 'bar', 1);
+    multi.hmset('2', 'foo', 2, 'bar', 2);
+    multi.hmset('3', 'foo', 3, 'bar', 3, 'baz', 3);
+    multi.hmset('4', 'foo', 4, 'bar', 4, 'baz', 4);
     multi.exec(assert.end);
 });
 
 tape('loadAttributes (using hashes)', function(assert) {
-    TileliveDecorator.loadAttributes(true, ['1', '2'], client, cache, function(err, replies, loaded) {
+    TileliveDecorator.loadAttributes(true, null, null, ['1', '2'], client, cache, function(err, replies, loaded) {
+        assert.ifError(err);
+        assert.deepEqual(replies, [{foo: '1', bar: '1'}, {foo: '2', bar: '2'}], 'loads');
+        assert.equal(loaded, 2, '2 items loaded from redis');
+        assert.end();
+    });
+});
+
+tape('loadAttributes (using hashes, keepKeys)', function(assert) {
+    cache.reset();
+    TileliveDecorator.loadAttributes(true, ['foo'], null, ['1', '2'], client, cache, function(err, replies, loaded) {
         assert.ifError(err);
         assert.deepEqual(replies, [{foo: '1'}, {foo: '2'}], 'loads');
-        assert.equal(loaded, 2, '2 items loaded from redis');
+        assert.end();
+    });
+});
+
+tape('loadAttributes (using hashes, requiredKeys)', function(assert) {
+    cache.reset();
+    TileliveDecorator.loadAttributes(true, ['foo', 'baz'], ['baz'], ['1', '2', '3', '4'], client, cache, function(err, replies, loaded) {
+        assert.ifError(err);
+        assert.deepEqual(replies, [null, null, {foo: '3', baz: '3'}, {foo: '4', baz: '4'}], 'loads');
         assert.end();
     });
 });


### PR DESCRIPTION
Prevents us hgetalling a bunch of data we will throw away.

Ended up reorganizing where filtering for `keepKeysRedis` and `requireKeysRedis` happen

cc @aaronlidman 